### PR TITLE
Quire support for path prefixes

### DIFF
--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -34,8 +34,8 @@ const shortcodesPlugin = require('~plugins/shortcodes')
 const syntaxHighlightPlugin = require('@11ty/eleventy-plugin-syntaxhighlight')
 const transformsPlugin = require('~plugins/transforms')
 
-const inputDir = 'content'
-const outputDir = '_site'
+const inputDir = process.env.ELEVENTY_INPUT || 'content'
+const outputDir = process.env.ELEVENTY_OUTPUT || '_site'
 const publicDir = 'public'
 
 /**
@@ -315,8 +315,8 @@ module.exports = function(eleventyConfig) {
      */
     dir: {
       // ⚠️ input and output dirs are _relative_ to the `.eleventy.js` module
-      input: process.env.ELEVENTY_INPUT || inputDir,
-      output: process.env.ELEVENTY_OUTPUT || outputDir,
+      input: inputDir,
+      output: outputDir,
       // ⚠️ the following directories are _relative_ to the `input` directory
       data: process.env.ELEVENTY_DATA || '_computed',
       includes: process.env.ELEVENTY_INCLUDES || path.join('..', '_includes'),

--- a/packages/11ty/.eleventy.js
+++ b/packages/11ty/.eleventy.js
@@ -7,6 +7,8 @@ const path = require('path')
 const scss = require('rollup-plugin-scss')
 const yaml = require('js-yaml');
 
+const chalkFactory = require('~lib/chalk')
+
 /**
  * Quire features are implemented as Eleventy plugins
  */
@@ -34,9 +36,39 @@ const shortcodesPlugin = require('~plugins/shortcodes')
 const syntaxHighlightPlugin = require('@11ty/eleventy-plugin-syntaxhighlight')
 const transformsPlugin = require('~plugins/transforms')
 
+const { error } = chalkFactory('eleventy config')
+
 const inputDir = process.env.ELEVENTY_INPUT || 'content'
 const outputDir = process.env.ELEVENTY_OUTPUT || '_site'
 const publicDir = 'public'
+
+/**
+ * Nota bene: Data cascade isn't available at config time,
+ * load publication data manually so that prefix can be used in config
+ * @todo refactor global data plugin to return global data for use in config
+ */
+const getPublicationPath = () => {
+  const publicationConfigPath = path.join(
+    inputDir,
+    '_data',
+    'publication.yaml'
+  )
+  const publication = yaml.load(fs.readFileSync(publicationConfigPath))
+  const { url } = publication
+  try {
+    let publicationPath = new URL(url).pathname
+    // Add trailing '/'
+    return !publicationPath.endsWith('/')
+      ? (publicationPath += '/')
+      : publicationPath
+  } catch (errorMessage) {
+    error(
+      `Publication.yaml url property must be a valid url. Current url value: "${url}"`
+    )
+    throw new Error(errorMessage)
+  }
+}
+const publicationPath = getPublicationPath()
 
 /**
  * Eleventy configuration
@@ -75,12 +107,6 @@ module.exports = function(eleventyConfig) {
   //     return addPassthroughCopy(entry, { expand: true })
   //   }
   // }
-
-  // Data cascade isn't available at config time(?), so load publication data manually
-  // NB: try / catch are uncaught here and in URL(), but presumably those should fail (or fail elsewhere in config validation)
-  const publicationConfigPath = path.join(inputDir,'_data','publication.yaml')
-  const publicationConfig = yaml.load(fs.readFileSync(publicationConfigPath)) 
-  const publicationPath = publicationConfig.url ? new URL(publicationConfig.url).pathname : '/';
 
   eleventyConfig.addGlobalData('application', {
     name: 'Quire',

--- a/packages/11ty/_includes/components/citation/page.js
+++ b/packages/11ty/_includes/components/citation/page.js
@@ -42,7 +42,7 @@ module.exports = function (eleventyConfig) {
       'publisher-place': publishers[0].location,
       title: pageTitle(page.data),
       type: 'chapter',
-      URL: new URL(page.url, url).toString()
+      URL: page.data.canonicalURL
     }
   }
 }

--- a/packages/11ty/_plugins/search/write.js
+++ b/packages/11ty/_plugins/search/write.js
@@ -15,16 +15,17 @@ module.exports = function(collections) {
     return content.split(' ').length
   }
 
-  const contentIndex = collections.html.map(({ data, templateContent, url }) => {
+  const contentIndex = collections.html.map(({ data, templateContent }) => {
+    const { abstract, canonicalURL, contributor, subtitle, title, layout } = data
     return {
-      abstract: data.abstract,
+      abstract,
       content: templateContent,
-      contributor: data.contributor,
+      contributor,
       length: wordcount(templateContent),
-      subtitle: data.subtitle,
-      title: data.title,
-      type: data.layout,
-      url
+      subtitle,
+      title,
+      type: layout,
+      url: canonicalURL
     }
   })
 


### PR DESCRIPTION
Changes:
- Use `canonicalURL` in search and citations
- Get `publication.url` in eleventy config - currently being done inline, though a better solution would be to refactor the global data plugin to (validate and) return global data, but doing so would affect the order that the plugin is loaded in and have some downstream effects so should probably be done in a separate PR.